### PR TITLE
v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ The class constructor has params to configure how you want to use the adapter:
 - `provider`: This param receives an object that is used to create `agent` and `actors`. The object needs to follow the interface `ActorAdapter.Provider`. We highly recommended using [@psychedelic/plug-inpage-provider](https://github.com/Psychedelic/plug-inpage-provider/packages/884575) if you want to instantiate actors linked to a user:
 
 ```ts
-const adapter = new ActorAdapter(window.plug);
+const adapter = new ActorAdapter(window.ic.plug);
 ```
 
 - `options`: This param is used for selecting some settings of network host and whitelisting canister ids. It follows the interface `ActorAdapter.Options`:
 
 ```ts
-const adapter = new ActorAdapter(window.plug, {
+const adapter = new ActorAdapter(window.ic.plug, {
   host: 'https://boundary.ic0.app/',
   whitelist: ['3xwpq-ziaaa-aaaah-qcn4a-cai'],
 });
@@ -176,17 +176,18 @@ To make actor creation even easier, Sonic-js provides two functions that automat
 
 The class `SwapCanisterController` provides methods that give access to the main functionalities of Swap Canister. Instantiation of a non-anonymous controller uses a `Swap Actor`.
 
-You can create an anonymous controller (not linked to any user) by providing no params:
+You can create an anonymous controller (not linked to any user):
 
 ```ts
-const controller = new SwapCanisterController();
+const swapActor = await createTokenActor();
+const controller = new SwapCanisterController(swapActor);
 ```
 
 Or adding a custom actor with your adapter:
 
 ```ts
 const swapActor = await createSwapActor({
-  actorAdapter: new ActorAdapter(window.plug),
+  actorAdapter: new ActorAdapter(window.ic.plug),
 });
 const controller = new SwapCanisterController(swapActor);
 ```
@@ -245,3 +246,4 @@ Declared types that are used to represent Sonic swap pairs.
 An object that stores the default values used inside the library.
 
 [Find it here](docs/README.md#default).
+

--- a/docs/classes/ActorAdapter.md
+++ b/docs/classes/ActorAdapter.md
@@ -64,7 +64,7 @@ ___
 
 ### createAnonymousActor
 
-▸ `Static` **createAnonymousActor**<`T`\>(`canisterId`, `interfaceFactory`, `host?`): [`Actor`](../modules/ActorAdapter.md#actor)<`T`\>
+▸ `Static` **createAnonymousActor**<`T`\>(`canisterId`, `interfaceFactory`, `host?`): `Promise`<[`Actor`](../modules/ActorAdapter.md#actor)<`T`\>\>
 
 #### Type parameters
 
@@ -82,7 +82,7 @@ ___
 
 #### Returns
 
-[`Actor`](../modules/ActorAdapter.md#actor)<`T`\>
+`Promise`<[`Actor`](../modules/ActorAdapter.md#actor)<`T`\>\>
 
 ___
 

--- a/docs/classes/SwapCanisterController.md
+++ b/docs/classes/SwapCanisterController.md
@@ -240,7 +240,7 @@ ___
 
 ### constructor
 
-• **new SwapCanisterController**(`swapActor?`)
+• **new SwapCanisterController**(`swapActor`)
 
 #### Parameters
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psychedelic/sonic-js",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "Sonic-js is a library that holds an API for interacting with Swap Canister",
   "main": "dist/index.js",
   "repository": "https://github.com/Psychedelic/sonic-js.git",

--- a/src/integrations/actor/adapter.ts
+++ b/src/integrations/actor/adapter.ts
@@ -54,7 +54,7 @@ export class ActorAdapter {
     let actor: ActorSubclass<T>;
 
     if (!this.provider) {
-      actor = ActorAdapter.createAnonymousActor(
+      actor = await ActorAdapter.createAnonymousActor(
         canisterId,
         interfaceFactory,
         this.options.host
@@ -113,15 +113,15 @@ export class ActorAdapter {
    * @param {string=ActorAdapter.DEFAULT_HOST} host The IC host to connect to
    * @returns {ActorAdapter.Actor<T>} The anonymous actor
    */
-  static createAnonymousActor<T>(
+  static async createAnonymousActor<T>(
     canisterId: string,
     interfaceFactory: IDL.InterfaceFactory,
     host = ActorAdapter.DEFAULT_HOST
-  ): ActorAdapter.Actor<T> {
+  ): Promise<ActorAdapter.Actor<T>> {
     const agent = new HttpAgent({ host, fetch });
 
     if (Default.ENV === 'development') {
-      agent.fetchRootKey();
+      await agent.fetchRootKey();
     }
 
     return Actor.createActor<T>(interfaceFactory, {

--- a/src/integrations/swap-canister/controller.ts
+++ b/src/integrations/swap-canister/controller.ts
@@ -1,4 +1,4 @@
-import { Default, Pair, Token, Types, SwapIDL } from '@/declarations';
+import { Default, Pair, Token, Types } from '@/declarations';
 import { Assets, Liquidity, Swap } from '@/math';
 import { toBigNumber } from '@/utils';
 import { Actor } from '@dfinity/agent';
@@ -19,14 +19,9 @@ export class SwapCanisterController {
   /**
    * Create an instance that communicates with swap canister.
    * Some of the functions uses the actor agent identity to identify the user that is interacting.
-   * @param {SwapActor} swapActor swap actor or an anonymous will be used
+   * @param {SwapActor} swapActor swap actor
    */
-  constructor(
-    private swapActor: SwapActor = ActorAdapter.createAnonymousActor<SwapIDL.Swap>(
-      Default.SWAP_CANISTER_ID,
-      SwapIDL.factory
-    )
-  ) {}
+  constructor(private swapActor: SwapActor) {}
 
   /**
    * Get the list of supported tokens from swap canister.

--- a/tests/integrations/swap-canister/controller.test.ts
+++ b/tests/integrations/swap-canister/controller.test.ts
@@ -39,10 +39,6 @@ describe('SwapCanisterController', () => {
     sut = new SwapCanisterController(swapActor);
   });
 
-  test('should instantiate without actor param', () => {
-    expect(() => new SwapCanisterController()).not.toThrow();
-  });
-
   describe('.getTokenList', () => {
     test('should return a parsed list of tokens', async () => {
       const response = await sut.getTokenList();
@@ -220,7 +216,7 @@ describe('SwapCanisterController', () => {
     });
 
     test('should throw if the principal is anonymous', async () => {
-      sut = new SwapCanisterController();
+      sut = new SwapCanisterController(mockSwapActor());
 
       (Actor.agentOf as jest.Mock).mockImplementationOnce(() =>
         mockAgent({


### PR DESCRIPTION
## Pull Request overview:

- Now `ActorAdapter.createAnonymousActor` is async. This turns able to use anonymous actors in local development;
- `SwapCanisterController` now needs the actor parameter to be initialized.
